### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: build
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   


### PR DESCRIPTION
Potential fix for [https://github.com/rmontesleo/forked-from-deuspaul-exer4-test/security/code-scanning/1](https://github.com/rmontesleo/forked-from-deuspaul-exer4-test/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file. The block should be placed at the top level (just below the `name` or `on` key) to apply to all jobs, unless a job needs more specific permissions. For this workflow, the minimal required permission is `contents: read`, as the jobs only need to check out code and upload artifacts, not write to the repository. No steps in the workflow require write access to repository contents, issues, or pull requests. The change should be made by inserting the following block after the `name: build` line:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
